### PR TITLE
Update the startup script for PureELK container to check for the ES endpoint

### DIFF
--- a/container/getPureElkIndex.py
+++ b/container/getPureElkIndex.py
@@ -1,16 +1,48 @@
-__author__ = 'terry'
-
 import sys
 from elasticsearch import Elasticsearch
 import time
+import requests
+import logging
+
+ES_ENDPOINT = "pureelk-elasticsearch:9200"
+logging.basicConfig(stream=sys.stdout, level=logging.INFO)
+
+def check_es_endpoint():
+    attempts = 3
+    while attempts > 0:
+        time.sleep(5)
+        status_code = 0
+
+        try: 
+            r = requests.get("http://{}".format(ES_ENDPOINT), timeout=5)
+            status_code = r.status_code
+        except Exception as e: 
+            logging.info("Error encountered when trying to connect to {}: {}".format(ES_ENDPOINT, e))
+
+        if status_code == 200:
+            logging.info("Successfully connected to elasticsearch endpoint at {}".format(ES_ENDPOINT))
+            break
+        else:     
+            attempts -= 1
+            logging.info("Not able to connect to {}, status code: {}, attempts remaining: {}".format(
+                ES_ENDPOINT, 
+                status_code,
+                attempts))
+
+    return attempts > 0
+
 
 if __name__ == '__main__':
-
-    time.sleep(5)
-    # create a connection to the Elasticsearch database
-    client = Elasticsearch(['pureelk-elasticsearch:9200'], retry_on_timeout=True)
-
-    if client.exists(index='.kibana', doc_type='index-pattern',id='pureelk-global-arrays'):
-        sys.exit(0)
+    exists = check_es_endpoint()
+    if exists:
+        # create a connection to the Elasticsearch database
+        client = Elasticsearch([ES_ENDPOINT], retry_on_timeout=True)
+        if client.exists(index='.kibana', doc_type='index-pattern',id='pureelk-global-arrays'):
+            logging.info("PureELK index patterns already exist.")
+            sys.exit(0)
+        else:
+            logging.info("PureElk index patterns do not exist yet.")
+            sys.exit(1)
     else:
-        sys.exit(1)
+        sys.exit(2)
+        

--- a/container/start.sh
+++ b/container/start.sh
@@ -1,5 +1,8 @@
 #! /bin/bash
 
+set -x
+
+#statements
 # This is the startup script for the container. See Dockerfile instructions.
 
 # Start the rabbitmq which is used by the Celery worker
@@ -25,11 +28,18 @@ export PYTHONPATH=$PYTHONPATH:/pureelk/web/:/pureelk/worker/
 # user just needs to navigate to kibana and start monitoring
 
 python ./getPureElkIndex.py
+
 if [ $? -eq 1 ]
     then
         # no pureelk-global-arrays index found, run elasticdump to import new index patterns and kibana dashboards
         # so users has a one-button experience
+        echo "Importing index patterns into elasticsearch..."
         /node_modules/elasticdump/bin/elasticdump --input=/pureelk/elasticdump_pureelk --output=http://elasticsearch:9200/.kibana
+elif [ $? -eq 2 ]
+    then
+        # Stop the container by erroring out from the script.
+        echo "Didn't detect elastic search cluster. Aborting..."
+        exit 1
 fi
 
 # Start the Flask web-site


### PR DESCRIPTION
Make sure the pureelk container waits for the ElasticSearch endpoint to be ready before moving forward. 

